### PR TITLE
Remove deprecated exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Remove deprecated Async.exists (#35 by @sigma-andex)
 - Update project and deps to PureScript v0.15.0 (#33 by @JordanMartinez, @thomashoneyman, @sigma-andex)
 - Update `mkdir'` to take options arg (#34 by @JordanMartinez)
 

--- a/src/Node/FS/Aff.purs
+++ b/src/Node/FS/Aff.purs
@@ -21,7 +21,6 @@ module Node.FS.Aff
   , writeTextFile
   , appendFile
   , appendTextFile
-  , exists
   , fdOpen
   , fdRead
   , fdNext
@@ -216,11 +215,6 @@ appendFile = toAff2 A.appendFile
 appendTextFile :: Encoding -> FilePath -> String -> Aff Unit
 appendTextFile = toAff3 A.appendTextFile
 
--- |
--- | Check to see if a file exists.
--- |
-exists :: String -> Aff Boolean
-exists file = makeAff \k -> A.exists file (pure >>> k) $> nonCanceler
 
 -- | Open a file asynchronously. See the [Node Documentation](https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback)
 -- | for details.


### PR DESCRIPTION
**Description of the change**

Remove `exists` since it was [removed from `purescript-node-fs`](https://github.com/purescript-node/purescript-node-fs/pull/61).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
