### PR TITLE
Add rmdir', rm, rm'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes:
 New features:
 
 - Update rmdir' to take options arg
-- Added rm and rm' version with and without options arg
+- Added rm and rm' versions with and without options arg
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 
 New features:
 
+- Update rmdir' to take options arg
+- Added rm and rm' version with and without options arg
+
 Bugfixes:
 
 Other improvements:

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "purescript-aff": "^7.0.0",
     "purescript-either": "^6.0.0",
-    "purescript-node-fs": "^8.0.0",
+    "purescript-node-fs": "^8.1.0",
     "purescript-node-path": "^5.0.0"
   },
   "devDependencies": {

--- a/src/Node/FS/Aff.purs
+++ b/src/Node/FS/Aff.purs
@@ -11,6 +11,9 @@ module Node.FS.Aff
   , realpath'
   , unlink
   , rmdir
+  , rmdir'
+  , rm
+  , rm'
   , mkdir
   , mkdir'
   , readdir
@@ -154,6 +157,25 @@ unlink = toAff1 A.unlink
 -- |
 rmdir :: FilePath -> Aff Unit
 rmdir = toAff1 A.rmdir
+
+-- |
+-- | Deletes a directory with options.
+-- |
+rmdir' :: FilePath -> { maxRetries :: Int, retryDelay :: Int } -> Aff Unit
+rmdir' = toAff2 A.rmdir'
+
+
+-- |
+-- | Deletes a file or directory.
+-- |
+rm :: FilePath -> Aff Unit
+rm = toAff1 A.rmdir
+
+-- |
+-- | Deletes a file or directory with options.
+-- |
+rm' :: FilePath -> { force :: Boolean, maxRetries :: Int, recursive :: Boolean, retryDelay :: Int } -> Aff Unit
+rm' = toAff2 A.rm'
 
 -- |
 -- | Makes a new directory.


### PR DESCRIPTION
**Description of the change**

Adds rmdir, rm, rm'


https://github.com/purescript-node/purescript-node-fs/pull/67/

Changes:

- Update `rmdir'` to take options arg
- Added `rm` and `rm'`  version with and witout options arg
 
---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
